### PR TITLE
Add nalgebra feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,9 @@ optional = true
 version = "0.10.3"
 optional = true
 
+[dependencies.nalgebra]
+version = "0.10.0"
+optional = true
+
 [dev-dependencies]
 sdl2 = "0.13.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 extern crate gl;
 #[cfg(feature = "cgmath")] extern crate cgmath;
 #[cfg(feature = "image")] extern crate image;
+#[cfg(feature = "nalgebra")] extern crate nalgebra;
 
 mod to_ref;
 
@@ -82,6 +83,7 @@ pub mod types;
 
 #[cfg(feature = "cgmath")] mod cgmath_features;
 #[cfg(feature = "image")] mod image_features;
+#[cfg(feature = "nalgebra")] mod nalgebra_features;
 
 pub use context::*;
 pub use buffer::*;

--- a/src/nalgebra_features/mod.rs
+++ b/src/nalgebra_features/mod.rs
@@ -1,0 +1,2 @@
+mod nalgebra_uniform_data;
+mod nalgebra_vertex_data;

--- a/src/nalgebra_features/nalgebra_uniform_data.rs
+++ b/src/nalgebra_features/nalgebra_uniform_data.rs
@@ -1,0 +1,38 @@
+use nalgebra;
+use uniform_data::{UniformDatumType, UniformDatum, UniformPrimitive};
+
+unsafe impl<T: UniformPrimitive> UniformDatum for nalgebra::Vector2<T> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Vec2(T::uniform_primitive_type())
+    }
+}
+
+unsafe impl<T: UniformPrimitive> UniformDatum for nalgebra::Vector3<T> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Vec3(T::uniform_primitive_type())
+    }
+}
+
+unsafe impl<T: UniformPrimitive> UniformDatum for nalgebra::Vector4<T> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Vec4(T::uniform_primitive_type())
+    }
+}
+
+unsafe impl UniformDatum for nalgebra::Matrix2<f32> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Matrix2x2
+    }
+}
+
+unsafe impl UniformDatum for nalgebra::Matrix3<f32> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Matrix3x3
+    }
+}
+
+unsafe impl UniformDatum for nalgebra::Matrix4<f32> {
+    fn uniform_datum_type() -> UniformDatumType {
+        UniformDatumType::Matrix4x4
+    }
+}

--- a/src/nalgebra_features/nalgebra_vertex_data.rs
+++ b/src/nalgebra_features/nalgebra_vertex_data.rs
@@ -1,0 +1,32 @@
+use nalgebra;
+use vertex_data::{VertexAttributeType, VertexDatum, VertexPrimitive};
+
+unsafe impl<T: VertexPrimitive> VertexDatum for nalgebra::Vector2<T> {
+    fn attrib_type() -> VertexAttributeType {
+        VertexAttributeType {
+            data: T::data_type(),
+            components: 2,
+            normalize: false
+        }
+    }
+}
+
+unsafe impl<T: VertexPrimitive> VertexDatum for nalgebra::Vector3<T> {
+    fn attrib_type() -> VertexAttributeType {
+        VertexAttributeType {
+            data: T::data_type(),
+            components: 3,
+            normalize: false
+        }
+    }
+}
+
+unsafe impl<T: VertexPrimitive> VertexDatum for nalgebra::Vector4<T> {
+    fn attrib_type() -> VertexAttributeType {
+        VertexAttributeType {
+            data: T::data_type(),
+            components: 4,
+            normalize: false
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the option (disabled by default) of using [nalgebra](https://crates.io/crates/nalgebra) with glitter, just as you can with cgmath. The option is disabled by default, so it's an opt-in change.

 The implementation was shamelessly cribbed from the cgmath_features module, so please tell me if there are any errors there.
