### PR TITLE
Fix build on nightly

### DIFF
--- a/src/vertex_data.rs
+++ b/src/vertex_data.rs
@@ -83,7 +83,7 @@ pub unsafe trait VertexData: Copy {
     /// (struct.VertexAttribute.html) passed to the function *must*
     /// be correct. See the [`VertexAttribute`](struct.VertexAttribute.html)
     /// docs for more details on what each field means.
-    fn visit_attributes<F>(&f: F) where F: FnMut(VertexAttribute);
+    fn visit_attributes<F>(f: F) where F: FnMut(VertexAttribute);
 }
 
 /// A single value that can be treated as a part of a vertex. Implementors


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/45775 turns some compatibility lints in `rustc` into hard errors and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/35203 for more information about the issue).
